### PR TITLE
(optional) Free Willy lifted state

### DIFF
--- a/src/components/dialogs/TransactionDialog.tsx
+++ b/src/components/dialogs/TransactionDialog.tsx
@@ -10,6 +10,8 @@ interface TransactionDialogProps {
     pollingMsg?: string,
     successMsg?: string,
     failureMsg?: string,
+    onSuccess?: (txInfo: TxInfo) => void,
+    onFail?: (txInfo: TxInfo) => void,
     onClose: () => void
 }
 
@@ -33,6 +35,8 @@ export function TransactionDialog(props: TransactionDialogProps) {
         pollingMsg = 'Please wait...',
         successMsg = <p>Transaction successful!: <a href={link} target="_blank">[TX Info]</a></p>,
         failureMsg = 'Transaction failure!',
+        onSuccess,
+        onFail,
         onClose
     } = props;
 
@@ -46,9 +50,15 @@ export function TransactionDialog(props: TransactionDialogProps) {
                     if (txInfo) {
                         if (txInfo.code === 0) {
                             setTransactionState(TransactionState.success);
-                            setLink(`https://finder.terra.money/${wallet?.network.chainID}/tx/${txInfo.txhash}`)
+                            setLink(`https://finder.terra.money/${wallet?.network.chainID}/tx/${txInfo.txhash}`);
+                            if (onSuccess) {
+                                onSuccess(txInfo);
+                            }
                         } else {
                             setTransactionState(TransactionState.fail);
+                            if (onFail) {
+                                onFail(txInfo);
+                            }
                         }
                     } else {
                         setTransactionState(TransactionState.timeout);

--- a/src/components/free-willy/FreeWilly.tsx
+++ b/src/components/free-willy/FreeWilly.tsx
@@ -3,29 +3,93 @@ import LiquidationBidChart from 'components/free-willy/LiquidationBidChart';
 import PlaceBid from 'components/free-willy/PlaceBid';
 import MyBids from 'components/free-willy/MyBids';
 import { Container, Paper, Grid } from '@mui/material';
+import useNetwork from 'hooks/useNetwork';
+import { useAnchorLiquidationContract, BidPool, Bid } from 'hooks/useAnchorLiquidationContract';
+import { useEffect, useState } from 'react';
+import { useConnectedWallet } from '@terra-money/wallet-provider';
 
 export function FreeWilly() {
+    const network = useNetwork();
+    const wallet = useConnectedWallet();
+
+    const { getBidPoolsByCollateral, getFilledBidsPendingClaimAmount, getBidsByUser } = useAnchorLiquidationContract(network.contracts.anchorLiquidation);
+    const [bethPools, setBethPools] = useState<BidPool[]>([]);
+    const [blunaPools, setBlunaPools] = useState<BidPool[]>([]);
+    const [bethBids, setBethBids] = useState<Bid[]>([]);
+    const [blunaBids, setBlunaBids] = useState<Bid[]>([]);
+    const [bethClaim, setBethClaim] = useState<number>(0);
+    const [blunaClaim, setBlunaClaim] = useState<number>(0);
+
+    useEffect(() => {
+        getBidPools().then()
+    }, [network])
+
+    useEffect(() => {
+        getBidsPendingClaim().then()
+    }, [wallet, network])
+
+    useEffect(() => {
+        getUserBids().then()
+    }, [wallet, network])
+
+    const getBidPools = async () => {
+        Promise.all([
+            getBidPoolsByCollateral(network.contracts.beth), 
+            getBidPoolsByCollateral(network.contracts.bluna)
+        ]).then(data => {
+            const [bethPools, blunaPools] = data;
+            setBethPools(bethPools.bid_pools);
+            setBlunaPools(blunaPools.bid_pools);
+        });
+    }
+
+    const getBidsPendingClaim = async () => {
+        if (wallet) {
+            Promise.all([
+                getFilledBidsPendingClaimAmount(network.contracts.beth),
+                getFilledBidsPendingClaimAmount(network.contracts.bluna)
+            ]).then(data => {
+                const [bethClaim, blunaClaim] = data;
+                setBethClaim(bethClaim);
+                setBlunaClaim(blunaClaim);
+            });
+        }
+    }
+
+    const getUserBids = async () => {
+        if (wallet) {
+            Promise.all([
+                getBidsByUser(network.contracts.beth),
+                getBidsByUser(network.contracts.bluna)
+            ]).then(data => {
+                const [bethBids, blunaBids] = data;
+                setBethBids(bethBids.bids);
+                setBlunaBids(blunaBids.bids);
+            });
+        }
+    }
+
     return (
         <Container sx={{maxWidth: '1200px', padding: '10px'}}>
             <Grid container spacing={2} >
                 <Grid item xs={12} sm={12}>
                     <Paper elevation={3}>
-                        <LiquidationBidChart/>
+                        <LiquidationBidChart bethPools={bethPools} blunaPools={blunaPools}/>
                     </Paper>
                 </Grid>
                 <Grid item xs={12} sm={6}>
                     <Paper elevation={3}>
-                        <PlaceBid />
+                        <PlaceBid onBidPlaced={getUserBids}/>
                     </Paper>
                 </Grid>
                 <Grid item xs={12} sm={6}>
                     <Paper elevation={3}>
-                        <LiquidationWithdrawals />
+                        <LiquidationWithdrawals bethClaim={bethClaim} blunaClaim={blunaClaim} onClaim={getBidsPendingClaim}/>
                     </Paper>
                 </Grid>
                 <Grid item xs={12}>
                     <Paper elevation={3}>
-                        <MyBids />
+                        <MyBids bethBids={bethBids} blunaBids={blunaBids}/>
                     </Paper>
                 </Grid>
             </Grid>

--- a/src/components/free-willy/LiquidationBidChart.tsx
+++ b/src/components/free-willy/LiquidationBidChart.tsx
@@ -1,12 +1,9 @@
 import { Typography, Stack } from "@mui/material";
-import { useConnectedWallet } from "@terra-money/wallet-provider";
-import useAddress from "hooks/useAddress";
-import { useAnchorLiquidationContract } from "hooks/useAnchorLiquidationContract";
-import useNetwork from "hooks/useNetwork";
+import { BidPool } from "hooks/useAnchorLiquidationContract";
 import { useEffect, useState } from "react";
 import { Bar } from "react-chartjs-2";
 
-export const options = {
+const options = {
     responsive: true,
     plugins: {
       legend: {
@@ -16,39 +13,7 @@ export const options = {
 };
 
 const defaultData = {
-    labels: [
-        "0%",
-        "1%",
-        "2%",
-        "3%",
-        "4%",
-        "5%",
-        "6%",
-        "7%",
-        "8%",
-        "9%",
-        "10%",
-        "11%",
-        "12%",
-        "13%",
-        "14%",
-        "15%",
-        "16%",
-        "17%",
-        "18%",
-        "19%",
-        "20%",
-        "21%",
-        "22%",
-        "23%",
-        "24%",
-        "25%",
-        "26%",
-        "27%",
-        "28%",
-        "29%",
-        "30%"
-    ], 
+    labels: new Array(31).fill(0).map((value, index) => `${index}%`), 
     datasets: [ 
         {
             label:"",
@@ -57,10 +22,13 @@ const defaultData = {
     ]
 }
 
+interface LiquidationBidChartProps {
+    bethPools: BidPool[],
+    blunaPools: BidPool[]
+}
 
-export default function LiquidationBidChart() {
-    const network = useNetwork();
-    const {getBidPoolsByCollateral} = useAnchorLiquidationContract(network.contracts.anchorLiquidation);
+export default function LiquidationBidChart(props: LiquidationBidChartProps) {
+    const {bethPools = [], blunaPools = []} = props;
     const [data, setData] = useState<any>(defaultData);
 
     const formatRate = (rate: string) => {
@@ -72,28 +40,23 @@ export default function LiquidationBidChart() {
     }
 
     useEffect(() => {
-        const bethPoolsPromise = getBidPoolsByCollateral(network.contracts.beth);
-        const blunaPoolsPromise = getBidPoolsByCollateral(network.contracts.bluna);
-        Promise.all([bethPoolsPromise, blunaPoolsPromise]).then(data => {
-            const [bethPools, blunaPools] = data;
-            const labels = bethPools.bid_pools.map(pool => formatRate(pool.premium_rate));
-            setData({
-                labels,
-                datasets: [
-                    {
-                        label: 'bLuna Bids',
-                        data: blunaPools.bid_pools.map(pool => formatBidAmount(pool.total_bid_amount)),
-                        backgroundColor: 'rgba(255, 99, 132, 0.5)'
-                    },
-                    {
-                        label: 'bEth Bids',
-                        data: bethPools.bid_pools.map(pool => formatBidAmount(pool.total_bid_amount)),
-                        backgroundColor: 'rgba(132, 99, 255, 0.5)'
-                    }
-                ],
-            })
+        const labels = bethPools.map(pool => formatRate(pool.premium_rate));
+        setData({
+            labels,
+            datasets: [
+                {
+                    label: 'bLuna Bids',
+                    data: blunaPools.map(pool => formatBidAmount(pool.total_bid_amount)),
+                    backgroundColor: 'rgba(255, 99, 132, 0.5)'
+                },
+                {
+                    label: 'bEth Bids',
+                    data: bethPools.map(pool => formatBidAmount(pool.total_bid_amount)),
+                    backgroundColor: 'rgba(132, 99, 255, 0.5)'
+                }
+            ],
         })
-    }, [network]);
+    }, [bethPools, blunaPools]);
 
     return (
         <Stack sx={{padding: '10px'}}>

--- a/src/components/free-willy/MyBids.tsx
+++ b/src/components/free-willy/MyBids.tsx
@@ -35,31 +35,28 @@ interface BidRow {
     collateral_token: string
 }
 
-export default function MyBids() {
+interface MyBidsProps {
+    bethBids: Bid[],
+    blunaBids: Bid[]
+}
+
+export default function MyBids(props: MyBidsProps) {
+    const { bethBids = [], blunaBids = [] } = props;
     const network = useNetwork();
-    const wallet = useConnectedWallet();
     const [rows, setRows] = useState<BidRow[]>([]);
-    const { getBidsByUser } = useAnchorLiquidationContract(network.contracts.anchorLiquidation);
-    
+
     useEffect(() => {
-        if (wallet) {
-            const bethBidsPromise = getBidsByUser(network.contracts.beth);
-            const blunaBidsPromise = getBidsByUser(network.contracts.bluna);
-            Promise.all([bethBidsPromise, blunaBidsPromise]).then(data => {
-                const [bethBids, blunaBids] = data;
-                const bids = [...bethBids.bids, ...blunaBids.bids];
-                setRows(bids.map(bid => {
-                    const collateralName = (bid.collateral_token === network.contracts.bluna) ? 'bLuna' : 'bEth';
-                    return {
-                        id: bid.idx,
-                        amount: `${parseInt(bid.amount) / 1000000} UST`,
-                        premium_slot: `${bid.premium_slot.toString()}%`,
-                        collateral_token: collateralName
-                    } as BidRow;
-                }))
-            })
-        }
-    }, [wallet, network])
+        const bids = [...bethBids, ...blunaBids];
+        setRows(bids.map(bid => {
+            const collateralName = (bid.collateral_token === network.contracts.bluna) ? 'bLuna' : 'bEth';
+            return {
+                id: bid.idx,
+                amount: `${parseInt(bid.amount) / 1000000} UST`,
+                premium_slot: `${bid.premium_slot.toString()}%`,
+                collateral_token: collateralName
+            } as BidRow;
+        }))
+    }, [bethBids, blunaBids, network])
 
     return (
         <Stack sx={{padding: '10px'}}>


### PR DESCRIPTION
Lifted all free willy state data to free willy component and pass down through props.  Added onSuccess and onFail props to transaction modal.

Doing this means that the components are effectively stupid and have no knowledge on how to get blockchain data.  For example, the My Bids chart no longer requests the data, but receives it through props which makes it more reusable.

This also allows a component that alters state to push an event to the parent.  The parent can then refresh the requried data.  For example, if someone places a bid, the My Bids chart needs to be refreshed.  So now, the Place Bids component pushes a onBid message to the parent.  the parent refreshes the users bids, then the parent passes the new bid data down to My Bids.

There are other methods to do this, but this is genererly know as Lifting state.